### PR TITLE
Fix typo in context processing comment

### DIFF
--- a/gpt_oss/metal/include/gpt-oss/functions.h
+++ b/gpt_oss/metal/include/gpt-oss/functions.h
@@ -267,7 +267,7 @@ enum gptoss_status GPTOSS_ABI gptoss_context_reset(
     gptoss_context_t context);
 
 /*
- * Pre-process the tokens in the Context and generate probability distrubution over the next token.
+ * Pre-process the tokens in the Context and generate probability distribution over the next token.
  *
  * @param context Context object created by gptoss_context_create.
  *


### PR DESCRIPTION
## Summary
- correct misspelling in `gptoss_context_process` comment

## Testing
- `pytest` *(fails: openai_harmony.HarmonyError: error downloading or loading vocab file)*

------
https://chatgpt.com/codex/tasks/task_e_6892d649eb988330826fa40a55a0b858