### PR TITLE
fix: correct typo in sampler comment

### DIFF
--- a/gpt_oss/evals/chat_completion_sampler.py
+++ b/gpt_oss/evals/chat_completion_sampler.py
@@ -59,7 +59,7 @@ class ChatCompletionSampler(SamplerBase):
                     response_metadata={"usage": response.usage},
                     actual_queried_message_list=message_list,
                 )
-            # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are reruning MMMU
+            # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are rerunning MMMU
             except openai.BadRequestError as e:
                 print("Bad Request Error", e)
                 return SamplerResponse(


### PR DESCRIPTION
## Summary
- fix typo in chat completion sampler comment

## Testing
- `PYTHONPATH=. pytest -q` *(fails: openai_harmony.HarmonyError: failed to download or load vocab file)*

------
https://chatgpt.com/codex/tasks/task_e_6892d64a0068833082b61a5600203c36